### PR TITLE
edit about shim camera library

### DIFF
--- a/shims/libgui_shim_miuicamera.c
+++ b/shims/libgui_shim_miuicamera.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdlib.h>
+
 void _ZN7android18BnProducerListener16onBufferDetachedEi() {
-    return;
+    exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Use the exit function instead of return, which cannot be used in void, and add the necessary libraries.